### PR TITLE
fix: add missing .cli suffix to metadata group

### DIFF
--- a/src/main/resources/metadata/cli.yaml
+++ b/src/main/resources/metadata/cli.yaml
@@ -1,4 +1,4 @@
-group: io.kestra.plugin.terraform
+group: io.kestra.plugin.terraform.cli
 name: "cli"
 title: "Terraform CLI"
 description: "Tasks that execute Terraform CLI operations."


### PR DESCRIPTION
## Summary
- `src/main/resources/metadata/cli.yaml` had `group: io.kestra.plugin.terraform` but the actual Java package is `io.kestra.plugin.terraform.cli`
- Fixed by appending `.cli` to the group value

## Test plan
- [ ] Verify `group` in `cli.yaml` matches `io.kestra.plugin.terraform.cli`