### PR TITLE
fix: fail the task when a terraform command fails

### DIFF
--- a/src/main/java/io/kestra/plugin/terraform/cli/TerraformCLI.java
+++ b/src/main/java/io/kestra/plugin/terraform/cli/TerraformCLI.java
@@ -56,11 +56,9 @@ import lombok.experimental.SuperBuilder;
                             username            = "cicd"
                             password            = "{{ secret('CI_CD_PASSWORD') }}"
                             hostname            = "https://demo.kestra.io"
-                        outputFiles:
-                          - "*.txt"
                         commands:
-                          - terraform plan 2>&1 | tee plan_output.txt
-                          - terraform apply -auto-approve 2>&1 | tee apply_output.txt
+                          - terraform plan
+                          - terraform apply -auto-approve
                         env:
                           AWS_ACCESS_KEY_ID: "{{ secret('AWS_ACCESS_KEY_ID') }}"
                           AWS_SECRET_ACCESS_KEY: "{{ secret('AWS_SECRET_ACCESS_KEY') }}"
@@ -114,11 +112,23 @@ public class TerraformCLI extends Task implements RunnableTask<ScriptOutput>, Na
         title = "Environment variables for commands",
         description = "Extra variables passed to the process; use for provider credentials and configuration."
     )
-    @PluginProperty(group = "execution", 
+    @PluginProperty(
+        group = "execution",
         additionalProperties = String.class,
         dynamic = true
     )
     protected Map<String, String> env;
+
+    @Schema(
+        title = "Fail the task on the first command with a non-zero exit status.",
+        description = """
+                If set to `false`, all commands run one after another and the task state is determined by the last command only.
+                Keep it enabled so a failing `terraform init`, `plan`, or `apply` fails the task instead of being reported as success.
+            """
+    )
+    @PluginProperty(group = "execution")
+    @Builder.Default
+    protected Property<Boolean> failFast = Property.ofValue(true);
 
     @Schema(
         title = "Deprecated Docker options",
@@ -168,6 +178,8 @@ public class TerraformCLI extends Task implements RunnableTask<ScriptOutput>, Na
             .withOutputFiles(renderedOutputFiles.isEmpty() ? null : renderedOutputFiles)
             .withInterpreter(Property.ofValue(List.of("/bin/sh", "-c")))
             .withBeforeCommands(this.beforeCommands)
+            .withBeforeCommandsWithOptions(true)
+            .withFailFast(runContext.render(this.failFast).as(Boolean.class).orElse(true))
             .withCommands(this.commands)
             .run();
     }

--- a/src/test/java/io/kestra/plugin/terraform/cli/TerraformCLITest.java
+++ b/src/test/java/io/kestra/plugin/terraform/cli/TerraformCLITest.java
@@ -19,6 +19,7 @@ import jakarta.inject.Inject;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @KestraTest
 class TerraformCLITest {
@@ -63,5 +64,26 @@ class TerraformCLITest {
         scriptOutput = runner.run(runContext);
         assertThat(scriptOutput.getExitCode(), is(0));
         assertThat(scriptOutput.getVars().get("customEnv"), is(environmentValue));
+    }
+
+    @Test
+    void failsWhenAnEarlyCommandFails() throws Exception {
+        TerraformCLI runner = TerraformCLI.builder()
+            .id(IdUtils.create())
+            .type(TerraformCLI.class.getName())
+            .docker(DockerOptions.builder().image("hashicorp/terraform").entryPoint(Collections.emptyList()).build())
+            .commands(
+                Property.ofValue(
+                    List.of(
+                        "terraform thiscommanddoesnotexist",
+                        "terraform version"
+                    )
+                )
+            )
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, runner, Map.of());
+
+        assertThrows(RunnableTaskException.class, () -> runner.run(runContext));
     }
 }


### PR DESCRIPTION
`TerraformCLI` extends `Task` directly instead of `AbstractExecScript`, so it never enabled fail-fast — unlike every other CLI plugin (dbt, trivy, databricks are `failFast=true` by default via `AbstractExecScript` + `withBeforeCommandsWithOptions(true)`). Without `set -e`, all commands run in one shell and the task exit code is only the last command's, so a failing `terraform init`/`plan`/`apply` was reported as SUCCESS.

Changes:
- Wire `withBeforeCommandsWithOptions(true)` + `withFailFast(...)` into the `CommandsWrapper`, which injects `set -e`.
- Add a `failFast` property defaulting to `true` (set `false` to opt back into the old "run all, take last exit code" behavior).
- Update the first example: drop `| tee ...`, which masks terraform's exit code through the pipe even with `set -e`.
- Add a regression test (`failsWhenAnEarlyCommandFails`): a failing command followed by a passing one now fails the task.

Fixes #77