### PR TITLE
fix(security): remediate OWASP/CWE audit findings (2026-06-30)

### DIFF
--- a/src/main/java/io/kestra/plugin/terraform/cli/TerraformCLI.java
+++ b/src/main/java/io/kestra/plugin/terraform/cli/TerraformCLI.java
@@ -117,6 +117,7 @@ public class TerraformCLI extends Task implements RunnableTask<ScriptOutput>, Na
         additionalProperties = String.class,
         dynamic = true
     )
+    @ToString.Exclude
     protected Map<String, String> env;
 
     @Schema(


### PR DESCRIPTION
## Summary

Remediates all findings from the 2026-06-30 automated security audit against OWASP Top 10 (2025), CWE Top 25, and OWASP ASVS Level 1.

## Findings Fixed

- **MEDIUM** @ToString exposes env map containing credential values (`src/main/java/io/kestra/plugin/terraform/cli/TerraformCLI.java:121`)
  - Fix: Added `@ToString.Exclude` to the `env` field to prevent Lombok from including credential values in `toString()` output, eliminating the risk of credential leakage into logs or audit trails.

## Testing

- [ ] `./gradlew build` passes
- [ ] No regressions in existing tests
- [ ] Manually verified the patched code paths

## References

- Security Audit EPIC: https://github.com/kestra-io/plugin-terraform/issues/92
- [Org-wide Security Meta-EPIC](https://github.com/kestra-io/kestra-ee/issues/9092)

---
*Automated security fix — please review each change carefully before merging.*
